### PR TITLE
Fix and comment some fake clock stuff

### DIFF
--- a/control/line_tacking_test.cc
+++ b/control/line_tacking_test.cc
@@ -81,17 +81,17 @@ class LineTackerTest : public ::sailbot::testing::TestWrapper {
   std::vector<std::thread> threads_;
 };
 
-TEST_F(LineTackerTest, DISABLED_DoesNothingOnNoData) {
+TEST_F(LineTackerTest, DoesNothingOnNoData) {
   Sleep(0.1);
 }
 
-TEST_F(LineTackerTest, DISABLED_GoesStraightBeamReach) {
+TEST_F(LineTackerTest, GoesStraightBeamReach) {
   SetupWaypoints(100, 0);
   receiver_.set_expected(0);
   Sleep(0.1);
 }
 
-TEST_F(LineTackerTest, DISABLED_GoesToReasonableTack) {
+TEST_F(LineTackerTest, GoesToReasonableTack) {
   SetupWaypoints(0, 100);
   receiver_.set_expected(0.8);
   receiver_.set_tolerance(0.2);

--- a/ui/server.h
+++ b/ui/server.h
@@ -22,7 +22,7 @@ class WebSocketServer : public Node {
   void ProcessSocket(uWS::WebSocket<uWS::SERVER> *ws, char *message,
                      size_t length, uWS::OpCode opcode);
   std::string GetCurrentVal(const std::string &msg);
-  void Iterate();
+  void Iterate() override;
 
   uWS::Hub hub_;
   const int port_;
@@ -31,6 +31,8 @@ class WebSocketServer : public Node {
   std::mutex send_map_mutex_;
   std::map<std::string, std::unique_ptr<Queue>> send_msgs_;
   std::vector<std::thread> threads_;
+  // Mutex so that we don't destroy the data that ProcessSocket needs too early
+  std::mutex process_mutex_;
   // The last time that we processed a socket request
   // TODO(james): Initialize apopriately
   std::mutex last_conn_mut_;

--- a/util/clock.cc
+++ b/util/clock.cc
@@ -63,6 +63,16 @@ void monotonic_clock::sleep_until(time_point time,
 
 ClockInstance::ClockInstance() : lck_(m_) {}
 
+ClockInstance::~ClockInstance() {
+  CleanUp();
+}
+
+void ClockInstance::CleanUp() {
+  if (lck_) {
+    lck_.unlock();
+  }
+}
+
 monotonic_clock::time_point ClockInstance::Time() {
   return monotonic_clock::now();
 }

--- a/util/clock.cc
+++ b/util/clock.cc
@@ -96,18 +96,25 @@ void ClockManager::Run(monotonic_clock::rep start_time) {
       first_run = false;
       monotonic_clock::set_time(monotonic_clock::next_wakeup_/*, lck*/);
     }
-    // TODO(james): This probably should be set_time(+Infinity), not next_wakeup.
+    // Strictly speaking, the time set here doesn't matter (as long as the
+    // time continue to monotonically increase), because the condition
+    // variable watiers in sleep_until will check wither IsShutdown() is
+    // true when we call set_time.
     monotonic_clock::set_time(monotonic_clock::next_wakeup_/*, lck*/);
   }
 }
 
 namespace {
-  std::atomic<bool> done{false};
-}
+// TODO(james): See TODO at prototype for CancelShutdown, but static state is
+// stupid.
+std::atomic<bool> done{false};
 
+// Handler to pass to signal()
 void SignalHandler(int signum) {
   RaiseShutdown();
 }
+
+} // namespace
 
 void CancelShutdown() {
   done = false;
@@ -129,6 +136,7 @@ void Init(int argc, char *argv[]) {
 
 void SetCurrentThreadRealtimePriority(int priority) {
   // Limit runtime of any single thread
+  // TODO(james): Test this to confirm it is actually doing what I think it is
   struct rlimit rlim;
   getrlimit(RLIMIT_RTTIME, &rlim);
   rlim.rlim_cur = 500000; // half a second
@@ -144,6 +152,8 @@ void SetCurrentThreadRealtimePriority(int priority) {
 bool IsShutdown() { return done; }
 void RaiseShutdown() {
   done = true;
+
+  // Only relevant for fake clock situations
   util::monotonic_clock::tick_.notify_all();
 }
 

--- a/util/clock.h
+++ b/util/clock.h
@@ -13,9 +13,46 @@
 namespace sailbot {
 namespace util {
 
+/**
+ * All of these classes have to do with timing and sleeping in the robot. In the
+ * nominal case where the code is running in real life, most of this is a
+ * relatively light wrapper over underlying calls to clock_nanosleep and
+ * clock_gettime with the right flags.
+ * This also contains the functions for the signal handling and global
+ * initialization of the process state.
+ *
+ * The more complex portion of this entire file is in handling the spoofing of
+ * system time for purposes of simulation and testing.
+ *
+ * General structure of the system time spoofing:
+ *
+ * monotonic_clock maintains the current time. This time is updated on the
+ * assumption that every thread actively running either doesn't care about time
+ * or has calls to monotonic_clock::sleep_until() occurring.
+ * All the different threads should, when they call sleep_until() be supplying
+ * the same, already locked as reader, shared mutex (this is automated by
+ * ClockInstance, which uses the static ClockInstance::m_). At all times,
+ * we maintain a next_wakeup, which is the earliest "time" that a thread
+ * will need to be awaken. Inside sleep_until, we pass on the lock to
+ * a condition variable which waits on the mutex.
+ * Once every thread that is maintaining a lock on ClockInstance::m_ has called
+ * sleep_until (or otherwise released their lock), ClockManager::Run (which must
+ * have been started by the process at some point) will obtain a writer's lock
+ * on the shared mutex and update the internal monotonic_clock time to
+ * monotonic_clock::next_wakeup_ and send out a notify_all on the condition
+ * variables.
+ * This will cause all the sleep_until's to wake up and check to see if their
+ * time has arrived. If it has, then they return and carry on; otherwise, they
+ * update next_wakeup_ (if necessary) and go back to waiting.
+ *
+ * For examples on usage, see util/testing.*
+ *
+ */
+
 class monotonic_clock {
  public:
   typedef std::chrono::nanoseconds duration;
+  // Our rep corresponds to one nanosecond.
   typedef duration::rep rep;
   typedef duration::period period;
   typedef std::chrono::time_point<monotonic_clock> time_point;
@@ -25,28 +62,45 @@ class monotonic_clock {
 
   static time_point now();
 
+  /*
+   * Sleep until a particular time, passing in an already locked shared lock l
+   * (which is only relevant when using a fake clock).
+   */
   static void sleep_until(time_point time,
                           std::shared_lock<std::shared_timed_mutex>& l);
 
   static bool is_fake() { return fake_clock; }
+
+  /*
+   * If running a fake clock, the time at which the nex tsleeping thread needs
+   * to be woken up.
+   */
   static rep next_wakeup() { return next_wakeup_; }
 
  private:
   static bool fake_clock;
+
+  // All of these member variables and methods are for when running the fake
+  // clock:
+
+  // Current time
   static std::atomic<rep> time_;
+  // condition variable to wake threads up
   static std::condition_variable_any tick_;
   static rep next_wakeup_;
   static std::mutex wakeup_time_mutex_;
 
+  // ClockInstance::m_ MUST be locked with a unique_lock if attempting to call
+  // set_time. This is to protect the interplay between time_ and next_wakeup_.
   static void set_time(rep time/*,
                        std::unique_lock<std::shared_timed_mutex>& unlock_lock*/) {
     time_ = time;
-    // TODO(james): Locking structure still isn't correct.
-    // TODO(james): Figure out if the above comment still applies.
-    //unlock_lock.unlock();
     tick_.notify_all();
   }
 
+  // ClockInstance::m_ MUST be locked as a reader if calling set_wakeup, to
+  // avoid potential issues with changing time_ while next_wakeup_ is being
+  // changed
   static void set_wakeup(rep time) {
     std::unique_lock<std::mutex> lck(wakeup_time_mutex_);
     if (next_wakeup_ <= time_) {
@@ -60,21 +114,46 @@ class monotonic_clock {
   friend void RaiseShutdown();
 };
 
+/**
+ * A clock for sleeping and getting current time.
+ * ONLY USE ONE PER THREAD; if you are running in a Node,
+ * then you already have access to a Time() function and
+ * you shouldn't be sleeping yourself.
+ * If you use more than one of these per thread, then
+ * you can never have two ClockInstance's sleeping at
+ * once, and as a consequence the fake clock will fail to work
+ * properly.
+ * TODO(james): Allow more than one ClockInstance per thread
+ */
 class ClockInstance {
  public:
   ClockInstance();
   ~ClockInstance();
   monotonic_clock::time_point Time();
   void SleepUntil(monotonic_clock::time_point time);
+  /**
+   * Performs all cleanup associated with this clock.
+   * In particular, unlocks the shared lock on m_,
+   * so that the fake clock can continue being iterated without
+   * expecting this instance to do anything.
+   */
   void CleanUp();
 
  private:
+  // The shared mutex so that we know when everyone has gone to sleep and we
+  // can update the fake clock.
   static std::shared_timed_mutex m_;
+  // Our individual lock on the mutex; locked from construction until
+  // CleanUp(), except when sleeping.
   std::shared_lock<std::shared_timed_mutex> lck_;
 
   friend class ClockManager;
 };
 
+/**
+ * Takes care of running the fake clock (well, and the real one, but nothing
+ * really needs to be *done* for the real clock).
+ */
 class ClockManager {
  public:
   static void SetFakeClock(bool is_fake, bool set_start_time=false) {
@@ -83,6 +162,9 @@ class ClockManager {
       monotonic_clock::set_time(0);
     }
   }
+  /**
+   * Manage the fake clock; start up in a thread of its own.
+   */
   static void Run(monotonic_clock::rep start_time);
 };
 
@@ -94,8 +176,18 @@ class ClockManager {
  */
 class Loop {
  public:
+  /**
+   * Construct a loop that loops with a period of period seconds.
+   */
   Loop(float period);
+  /*
+   * Wait for the next loop iteration to occur.
+   */
   void WaitForNext();
+  /**
+   * Perform cleanup when we are done looping. Mostly important with
+   * the fake clock.
+   */
   void Done() { clock_.CleanUp(); }
   monotonic_clock::time_point Time() { return clock_.Time(); }
 
@@ -107,9 +199,18 @@ class Loop {
 
 // Should be called at the start of every PROCESS (not Node).
 void Init(int argc, char *argv[]);
+// Returns whether the process is terminating and the current thread should
+// attempt to exit.
 bool IsShutdown();
+// For testing purposes, resets the flag states so that we are no longer
+// shutting down.
+// TODO(james): This is poor style, as it relies on us remembering to call
+//   it in testing to clear static variable state. Instead, require some
+//   form of initialization on every test to statically enforce this.
 void CancelShutdown();
+// Indicate to other threads that it is time to shut down.
 void RaiseShutdown();
+// Sets thread priority.
 void SetCurrentThreadRealtimePriority(int priority);
 
 }  // util

--- a/util/clock.h
+++ b/util/clock.h
@@ -63,16 +63,10 @@ class monotonic_clock {
 class ClockInstance {
  public:
   ClockInstance();
-  ~ClockInstance() {
-    CleanUp();
-  }
+  ~ClockInstance();
   monotonic_clock::time_point Time();
   void SleepUntil(monotonic_clock::time_point time);
-  void CleanUp() {
-    if (lck_) {
-      lck_.unlock();
-    }
-  }
+  void CleanUp();
 
  private:
   static std::shared_timed_mutex m_;

--- a/util/node.cc
+++ b/util/node.cc
@@ -15,15 +15,12 @@ Node::~Node() {
 }
 
 void Node::Run() {
-  if (period_ < 0) {
-    return;
-  }
-  while (!util::IsShutdown()) {
+  while (period_ >= 0 && !util::IsShutdown()) {
     if (period_ > 0) {
       loop_.WaitForNext();
     }
     if (util::IsShutdown()) {
-      return;
+      break;
     }
     Iterate();
   }

--- a/util/testing.cc
+++ b/util/testing.cc
@@ -14,7 +14,6 @@ TestWrapper::TestWrapper() {
 }
 
 TestWrapper::~TestWrapper() {
-  clock_.reset();
   clock_manager_thread_->join();
 }
 

--- a/util/testing.h
+++ b/util/testing.h
@@ -19,6 +19,7 @@ class TestWrapper : public ::testing::Test {
 
   void TearDown() override {
     util::RaiseShutdown();
+    clock_.reset();
   }
 
  private:


### PR DESCRIPTION
There were some multi-threading issues with how the fake clock (used when spoofing time so we can run simulations and the such) behaves when shutting down. Basically, in the wrong conditions, a couple of different places could end up not releasing their locks early enough, resulting in a deadlock.

If anyone wants more comments in places (or current comments are incomprehensible), just note that.